### PR TITLE
RDMSG-381: Add conversation.xmpp_ip

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -909,6 +909,7 @@ See [reading section](#responses-read) to discover some output examples.
 | skill_id | Skill indentifier | Integer |
 | tag_list | List of tag identifiers | List of integers |
 | rule_id | Rule indentifier | Integer |
+| xmpp_id | XMPP related identifier | UUID |
 
 #### Tag
 


### PR DESCRIPTION
Ajout de la documentation pour un champ nouvellement exposé sur la ressource `/conversation`

Le champ s'appelle `xmpp_id` et correspond au champ `chat_history.conversation_id` -> identifiant xmpp