### PR TITLE
HOTFIX: remove wrong sentence for webhook retry

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -1470,8 +1470,6 @@ Content-Length: 3442
 }
 </pre>
 
-**Retry management**
-iAdvize will retry to send callback in failure X times if http status code isn’t part of 50x code.
 
 ## Delivery headers
 iAdvize will send payload with two additionals headers:


### PR DESCRIPTION
#### Description
HOTFIX: remove wrong sentence for webhook retry

