### PR TITLE
doc: Remove deprecation warning about JS Callbacks

### DIFF
--- a/docs/javascript-callbacks.md
+++ b/docs/javascript-callbacks.md
@@ -2,8 +2,6 @@
 
 iAdvize provides Javascript callbacks functions that can be used to perform actions on specific events.
 
-*Please be advised that on Q4 of 2019 iAdvize will deliver a new Javascript SDK containing much more features. Current callbacks will be deprecated but we will insure a smooth transition for existing integrations.*
-
 ## How to use callbacks
 
 To execute custom code during an iAdvize callback function you have to define a `var iAdvizeCallbacks;` variable that will contain the callbacks you want to use. **You must declare that variable before iAdvize tracking code.**


### PR DESCRIPTION
#### What's this PR purpose?

- [x] Remove deprecation warning about JS Callbacks (waiting for more feedback about swarm messaging)