### PR TITLE
doc: remove deprecated mention

### DIFF
--- a/Navigation.md
+++ b/Navigation.md
@@ -40,7 +40,7 @@
     * [~~Satisfaction~~ (deprecated)](/documentation/rest-api#satisfaction-deprecated)
     * [Statistic](/documentation/rest-api#statistic)
     * [Visitor](/documentation/rest-api#visitor)
-    * [~~Call meeting~~ (deprecated)](/documentation/rest-api#call-meeting-deprecated)
+    * [Call meeting](/documentation/rest-api#call-meeting)
 * [Webhooks](/documentation/webhooks#webhooks)
   * [Overview](/documentation/webhooks#overview-webhooks)
     * [Delivery headers](/documentation/webhooks#delivery-headers)

--- a/docs/rest-api.md
+++ b/docs/rest-api.md
@@ -841,7 +841,7 @@ See [reading section](#read) to discover some output examples.
 | website_id | List of website identifiers | List of integers |
 | created_at | Visitor creation date | Date `YYYY-MM-DD HH:MM:SS` |
 
-### ~~Call meeting~~ deprecated
+### Call meeting
 
 #### Get call meetings
 
@@ -862,8 +862,8 @@ See below to discover used fields and see [reading section](#read) to discover s
 | Field | Description | Values |
 | --- | --- | --- |
 | id | Call meeting identifier | Integer |
+| unique_id | Visitor unique identifier | String |
 | phone_number | Visitor phone number | String |
-| visitor_uid | Visitor unique identifier | String |
 | status | Call meeting status (pending, progress, done, failed, working) | String |
 | start_at | Date of call | DateTime |
 | website_id | Website identifier | Integer |


### PR DESCRIPTION
#### Description
As we have no alternative to propose in GraphQL, we remove the deprecated mention.