### PR TITLE
doc/TPC-1301-reactnative-integration-issues

### DIFF
--- a/docs/mobile-sdk.md
+++ b/docs/mobile-sdk.md
@@ -231,7 +231,8 @@ IAdvizeSDK.activate(
 You can choose between multiple authentication options:
 
 - **anonymous**: when you have an unidentified user browsing your app
-- **simple(userId: String)**: when you have a logged in user in your app. You must pass a unique identifier so that the visitor will retrieve his conversation history across multiple devices and platforms
+- **simple**: when you have a logged in user in your app. You must pass a unique string identifier (*userId*) so that the visitor will retrieve his conversation history across multiple devices and platforms
+- **secured**: use it in conjunction with your in-house authentication system. You must pass a *JWE provider* callback that will be called when an authentication is required, you will then have to call your third party authentication system for a valid JWE to provide to the SDK
 
 > *⚠️ For the __simple__ authentication mode, the identifier that you pass must be __unique and non-discoverable for each different logged-in user__.*
 

--- a/docs/mobile-sdk.md
+++ b/docs/mobile-sdk.md
@@ -53,6 +53,20 @@ Hybrid plugins for the iAdvize Conversation SDK are also available:
 
 > *⚠️ Please note that there may be delays between Native SDK releases and the corresponding hybrid plugins update deliveries.*
 
+##### ReactNative
+
+Our iOS SDK is delivered as a binary framework (in an XCFramework bundle), which is a standard way of distributing closed-source binaries. The SDK relies on external dependencies to provide several rich features. These dependencies are not directly integrated into our SDK. They are installed in your app at the same time the SDK is installed (when executing the `pod install` command). Thus, our SDK and its dependencies must be linked dynamically. For this reason, the `use_frameworks!` option is required in the `Podfile`, to ensure CocoaPods use dynamic frameworks instead of static libraries. For the same reason, the `use_frameworks! :linkage => :static` directive will not work.
+
+The ReactNative applications integrating our SDK through our ReactNative wrapper module should also use this `use_frameworks!` option in the iOS app configuration `Podfile` in order for it to compile and run.
+
+Some ReactNative base libraries like `Flipper` or `Hermes` do not work well with this option. ReactNative documentation recommends to disable `Flipper` when applying the `use_frameworks!` option.
+https://github.com/facebook/flipper/issues?q=is%3Aissue+is%3Aopen+use_frameworks
+
+As for `Hermes` the compatibility with `use_frameworks!` may be possible depending on your project dependencies & machine (Apple Silicon or Intel). Various workarounds can be found that may or may not work for your precise environment. Here are some useful links describing them:
+https://github.com/facebook/react-native/issues/34381
+https://github.com/facebook/react-native/issues/34344
+https://github.com/facebook/react-native/issues/31941
+
 ### ⚙️ Setting up the SDK
 
 #### 1️⃣ Adding the SDK dependency

--- a/docs/mobile-sdk.md
+++ b/docs/mobile-sdk.md
@@ -47,9 +47,9 @@ The latest release version for the SDK can be found on the public Github reposit
 
 Hybrid plugins for the iAdvize Conversation SDK are also available:
 
-| ReactNative |
-| ----------- |
-| [https://github.com/iadvize/iadvize-react-native-sdk](https://github.com/iadvize/iadvize-react-native-sdk) |
+| ReactNative | Flutter |
+| ----------- | ------- |
+| [https://github.com/iadvize/iadvize-react-native-sdk](https://github.com/iadvize/iadvize-react-native-sdk) | [https://github.com/iadvize/iadvize-flutter-sdk](https://github.com/iadvize/iadvize-flutter-sdk) |
 
 > *⚠️ Please note that there may be delays between Native SDK releases and the corresponding hybrid plugins update deliveries.*
 


### PR DESCRIPTION
#### What's this PR purpose?
> [Fix documentation & methods for Secured Messaging on SDKs](https://iadvize.atlassian.net/browse/TPC-1301)

#### Description
- add a disclaimer for ReactNative SDK on iOS concerning the `use_frameworks!` necessity
- add documentation for `secured` authentication option
- add Flutter SDK link
